### PR TITLE
French translations

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  locales: ['en-us', 'es'],
+  locales: ['en-us', 'es', 'fr'],
   namespaceSeparator: false,
   keySeparator: false,
   useKeysAsDefaultValue: true,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,6 +2,7 @@ import { createInstance } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import moment from 'moment';
 import 'moment/locale/es';
+import 'moment/locale/fr';
 import localeEnUS from './locales/en-us/translation.json';
 import localeEs from './locales/es/translation.json';
 import localeFr from './locales/fr/translation.json';
@@ -31,7 +32,7 @@ const i18n = createInstance({
     es: {
       translation: localeEs,
     },
-    'fr': {
+    fr: {
       translation: localeFr,
     }
   },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,10 +4,12 @@ import moment from 'moment';
 import 'moment/locale/es';
 import localeEnUS from './locales/en-us/translation.json';
 import localeEs from './locales/es/translation.json';
+import localeFr from './locales/fr/translation.json';
 
 const englishUS = 'en-us';
 const spanish = 'es';
-const SUPPORTED_LOCALES = [englishUS, spanish];
+const french = 'fr';
+const SUPPORTED_LOCALES = [englishUS, spanish, french];
 
 const i18n = createInstance({
   fallbackLng: englishUS,
@@ -29,6 +31,9 @@ const i18n = createInstance({
     es: {
       translation: localeEs,
     },
+    'fr': {
+      translation: localeFr,
+    }
   },
 });
 

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,10 @@
+{
+  "Online": "En ligne",
+  "Last seen {{date, dateRelative}}": "Vu pour la dernière fois {{date, dateRelative}}",
+  "{{device}} Device": "Appareil {{device}}",
+  "{{browser}} on {{os}}": "{{browser}} sur {{os}}",
+  "<0>Connected to </0>{{deviceType}}": "<0>Connecté à </0>{{deviceType}}",
+  "{{date, dateRelative}}": "{{date, dateRelative}}",
+  "Recorded": "Enregistré",
+  "Active": "Actif"
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,6 +1,6 @@
 {
   "Online": "En ligne",
-  "Last seen {{date, dateRelative}}": "Vu pour la dernière fois {{date, dateRelative}}",
+  "Last seen {{date, dateRelative}}": "Vu {{date, dateRelative}}",
   "{{device}} Device": "Appareil {{device}}",
   "{{browser}} on {{os}}": "{{browser}} sur {{os}}",
   "<0>Connected to </0>{{deviceType}}": "<0>Connecté à </0>{{deviceType}}",


### PR DESCRIPTION
added as per the spec given in Trello. I wanted to match the style of what was there for spanish, so I also added `const french = 'fr'`, hope that's ok. This has not been tested by me.