### PR TITLE
Default to English dates if no locale has been set previously

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -42,6 +42,9 @@ i18n
   .use(initReactI18next)
   .init()
 
+// Default to English on load
+moment.locale(englishUS)
+
 i18n.on('languageChanged', (language) => {
   // Fall back to US English if we don't currently support the selected language
   if (SUPPORTED_LOCALES.indexOf(language) === -1) {


### PR DESCRIPTION
Load the English moment translations by default. This should fix an issue where French dates are shown if the app that's using this library does not use i18next (or it does not initialise it when the app loads).