### PR TITLE
Update Babel config to output ES modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
     "presets": [
-        "@babel/env",
+        ["@babel/env", {
+            "modules": false
+        }],
         "@babel/preset-react"
     ],
     "plugins": [


### PR DESCRIPTION
Before this change, we were converting the components to CommonJS which makes really difficult for bundlers to do tree-shaking properly. Any conversions should be done by the importing app's bundler.