### PR TITLE
fix: retain focus when code entry is invalid

### DIFF
--- a/src/CodeEntry.js
+++ b/src/CodeEntry.js
@@ -39,14 +39,14 @@ export default class CodeEntry extends Component {
       if (await this.props.onCode(code)) {
         this.setState({ validating: false })
         this.setState({ code: ['', '', '', '', '', ''] })
-        if (this.firstDigit) this.firstDigit.focus()
+        if (this.firstDigit) setTimeout(() => this.firstDigit.focus(), 0)
       } else {
         this.setState({ validating: false })
-        if (this.lastDigit) this.lastDigit.focus()
+        if (this.lastDigit) setTimeout(() => this.lastDigit.focus(), 0)
       }
     } catch (e) {
       this.setState({ validating: false })
-      if (this.lastDigit) this.lastDigit.focus()
+      if (this.lastDigit) setTimeout(() => this.lastDigit.focus(), 0)
       throw e
     }
   }


### PR DESCRIPTION
**Steps to reproduce:**

1. Setup a React app that uses the CodeEntry component

```js
import {CodeEntry} from 'cobrowse-agent-ui'

function App() {
    const handleCode(code) {
        // Reject all codes
        return false
    }

    return <CodeEntry onCode={handleCode} />
}
```

2. Enter a 6 digit code

**Expected behaviour:**

The code entry should shake to indicate the code is invalid. The last input should remain focused so it is easy to correct the code

**Actual behaviour:**

The code entry shakes but the last input is not focused so someone has to click on the input.