### PR TITLE
feat: add a BlockingError component

### DIFF
--- a/lib/integrations/components/BlockingError/BlockingError.module.css
+++ b/lib/integrations/components/BlockingError/BlockingError.module.css
@@ -1,0 +1,19 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px;
+  height: 100%;
+  text-align: center;
+}
+
+.heading {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.message {
+  font-size: 1.2rem;
+}

--- a/lib/integrations/components/BlockingError/index.tsx
+++ b/lib/integrations/components/BlockingError/index.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import styles from './BlockingError.module.css'
+
+export interface BlockingErrorProps {
+  message?: string
+  children?: ReactNode
+}
+
+const BlockingError = ({ message, children }: BlockingErrorProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.root}>
+      <p className={styles.heading}>{t('Sorry, something went wrong.')}</p>
+      {message && <p className={styles.message}>{message}</p>}
+      {children}
+    </div>
+  )
+}
+
+export default BlockingError

--- a/lib/integrations/index.ts
+++ b/lib/integrations/index.ts
@@ -1,1 +1,2 @@
 export { default as Tabs, type TabsProps } from './components/Tabs'
+export { default as BlockingError, type BlockingErrorProps } from './components/BlockingError'


### PR DESCRIPTION
This adds a generic "blocking" (i.e. not recoverable) error component.

The "Back to safety" behaviour will be up to the app implementing this component as it could be a React Router Link component, a simple anchor tag or nothing. We don't really want to dictate what it should be or create a hard link here.

<img width="362" height="484" alt="image" src="https://github.com/user-attachments/assets/ad7f246c-5761-4b33-a09e-15f30f7cceb4" />
