### PR TITLE
chore: trim whitespace from pasted 6 digit code

### DIFF
--- a/lib/components/CodeEntry/index.tsx
+++ b/lib/components/CodeEntry/index.tsx
@@ -142,7 +142,7 @@ const CodeEntry = ({ ref, className, inputClassName, focusOnRender = false, onCo
     }
 
     const { clipboardData } = event
-    const pastedData = clipboardData.getData('Text')
+    const pastedData = clipboardData.getData('Text').trim()
 
     // Exit early if the pasted data contains anything other than just digits
     if (!/^[0-9]+$/.test(pastedData)) {


### PR DESCRIPTION
I noticed that double-clicking the six-digit code in our example app to select it includes a trailing newline character.

The Code Entry component ignored the code when attempting to paste it with this newline included.