### PR TITLE
feat: add optional heading to BlockingError

### DIFF
--- a/lib/components/BlockingError/index.tsx
+++ b/lib/components/BlockingError/index.tsx
@@ -3,16 +3,17 @@ import { useTranslation } from '@/i18n'
 import styles from './BlockingError.module.css'
 
 export interface BlockingErrorProps {
+  heading?: string
   message?: string
   children?: ReactNode
 }
 
-const BlockingError = ({ message, children }: BlockingErrorProps) => {
+const BlockingError = ({ heading, message, children }: BlockingErrorProps) => {
   const { t } = useTranslation()
 
   return (
     <div className={styles.root}>
-      <p className={styles.heading}>{t('Sorry, something went wrong.')}</p>
+      <p className={styles.heading}>{heading ?? t('Sorry, something went wrong.')}</p>
       {message && <p className={styles.message}>{message}</p>}
       {children}
     </div>


### PR DESCRIPTION
Add a heading override so we can achieve something like this in the dynamics integration:

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/06e91317-fefa-4b24-9fc2-2696271737ab" />
