### PR TITLE
fix: improve CodeEntry keys behaviour

### DIFF
--- a/lib/components/CodeEntry/index.tsx
+++ b/lib/components/CodeEntry/index.tsx
@@ -68,6 +68,7 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
   const [validating, setValidating] = useState(false)
   const [code, setCode] = useState(EMTPY_STATE)
   const refs = useRef<Array<HTMLInputElement | null>>([])
+  const focusTargetRef = useRef<number | null>(null)
 
   useImperativeHandle(ref, () => ({
     clear () {
@@ -95,23 +96,26 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
 
       if (isValid) {
         setCode(EMTPY_STATE)
-
-        if (refs.current[0]) {
-          setTimeout(() => refs.current[0]?.focus(), 0)
-        }
+        focusTargetRef.current = 0
       } else {
-        setTimeout(() => refs.current[CODE_LENGTH - 1]?.focus(), 0)
+        focusTargetRef.current = CODE_LENGTH - 1
       }
-    } catch (e) {
-      if (refs.current[CODE_LENGTH - 1]) {
-        setTimeout(() => refs.current[CODE_LENGTH - 1]?.focus(), 0)
-      }
-
-      throw e
+    } catch {
+      focusTargetRef.current = CODE_LENGTH - 1
     } finally {
       setValidating(false)
     }
   }, [onCode])
+
+  // Restore focus once validation completes and the inputs are re-enabled
+  useEffect(() => {
+    if (validating || focusTargetRef.current === null) {
+      return
+    }
+
+    refs.current[focusTargetRef.current]?.focus()
+    focusTargetRef.current = null
+  }, [validating])
 
   // Run the tryComplete function when the code state changes
   useEffect(() => {

--- a/lib/components/CodeEntry/index.tsx
+++ b/lib/components/CodeEntry/index.tsx
@@ -8,7 +8,8 @@ import {
   type ReactNode,
   type ClipboardEvent,
   type ChangeEvent,
-  type KeyboardEvent
+  type KeyboardEvent,
+  type FocusEvent
 } from 'react'
 import clsx from 'clsx'
 import { useTranslation } from '@/i18n'
@@ -175,17 +176,12 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
     const digit = parseInt(target.getAttribute('data-digit') ?? '0', 10)
     const digits = value.match(/[0-9]/g) ?? []
 
-    if (digits.length === 0) {
-      setDigit(digit, '')
-
-      return
-    }
-
-    if (digits.length === 1) {
-      setDigit(digit, digits[0])
-      focusNextInput(refs.current, target)
-    }
+    setDigit(digit, digits[digits.length - 1] ?? '')
   }, [setDigit])
+
+  const handleFocus = useCallback((event: FocusEvent<HTMLInputElement>) => {
+    event.currentTarget.select()
+  }, [])
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
     const { key, currentTarget, metaKey, ctrlKey } = event
@@ -205,10 +201,10 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
   }, [])
 
   const handleKeyUp = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
-    const { currentTarget, repeat } = event
+    const { key, currentTarget, repeat } = event
     const { value } = currentTarget
 
-    if (!repeat && /[0-9]/.test(value)) {
+    if (!repeat && key.length === 1 && value !== '') {
       focusNextInput(refs.current, currentTarget)
     }
   }, [])
@@ -237,6 +233,7 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
             onKeyDown={handleKeyDown}
             onKeyUp={handleKeyUp}
             onChange={handleOnChange}
+            onFocus={handleFocus}
             onPaste={handlePaste}
             value={value}
             data-digit={index}

--- a/lib/components/CodeEntry/index.tsx
+++ b/lib/components/CodeEntry/index.tsx
@@ -23,6 +23,7 @@ export interface CodeEntryProps {
   ref?: ForwardedRef<CodeEntryHandle>
   className?: string
   inputClassName?: string
+  labelClassName?: string
   focusOnRender?: boolean
   onCode?: (code: string) => Promise<boolean> | boolean
   label?: ReactNode | false
@@ -61,7 +62,7 @@ const moveFocusForArrowKey = (
   }
 }
 
-const CodeEntry = ({ ref, className, inputClassName, focusOnRender = false, onCode, label, children }: CodeEntryProps) => {
+const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRender = false, onCode, label, children }: CodeEntryProps) => {
   const { t } = useTranslation()
   const [validating, setValidating] = useState(false)
   const [code, setCode] = useState(EMTPY_STATE)
@@ -220,7 +221,7 @@ const CodeEntry = ({ ref, className, inputClassName, focusOnRender = false, onCo
     >
       {label !== false && (
         <legend
-          className={styles.legend}
+          className={clsx(styles.legend, labelClassName)}
           onClick={focusFirstEmptyInput}
         >
           <span>{label ?? t('Support code')}</span>

--- a/lib/components/CodeEntry/index.tsx
+++ b/lib/components/CodeEntry/index.tsx
@@ -69,6 +69,7 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
   const [code, setCode] = useState(EMTPY_STATE)
   const refs = useRef<Array<HTMLInputElement | null>>([])
   const focusTargetRef = useRef<number | null>(null)
+  const advancedOnChange = useRef(false)
 
   useImperativeHandle(ref, () => ({
     clear () {
@@ -179,8 +180,14 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
     const { target, target: { value } } = event
     const digit = parseInt(target.getAttribute('data-digit') ?? '0', 10)
     const digits = value.match(/[0-9]/g) ?? []
+    const nextValue = digits[digits.length - 1] ?? ''
 
-    setDigit(digit, digits[digits.length - 1] ?? '')
+    setDigit(digit, nextValue)
+
+    if (nextValue !== '') {
+      focusNextInput(refs.current, target)
+      advancedOnChange.current = true
+    }
   }, [setDigit])
 
   const handleFocus = useCallback((event: FocusEvent<HTMLInputElement>) => {
@@ -188,6 +195,7 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
   }, [])
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+    advancedOnChange.current = false
     const { key, currentTarget, metaKey, ctrlKey } = event
 
     // On backspace on empty node go back to previous
@@ -206,9 +214,14 @@ const CodeEntry = ({ ref, className, inputClassName, labelClassName, focusOnRend
 
   const handleKeyUp = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
     const { key, currentTarget, repeat } = event
-    const { value } = currentTarget
 
-    if (!repeat && key.length === 1 && value !== '') {
+    if (advancedOnChange.current) {
+      advancedOnChange.current = false
+
+      return
+    }
+
+    if (!repeat && key.length === 1 && currentTarget.value !== '') {
       focusNextInput(refs.current, currentTarget)
     }
   }, [])


### PR DESCRIPTION
These changes improve the behaviour when typing into CodeEntry. It should feel more responsive after each key press and the re-focus when entering a wrong code should now work more consistently.

This PR includes the changes from https://github.com/cobrowseio/cobrowse-agent-ui/pull/60.